### PR TITLE
feat: add CI/CD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,8 @@ on:
     branches: [ main ]
 
 jobs:
-  deploy-macos-linux:
-    name: Compile MacOS/Linux Application
+  deploy:
+    name: Compile Application
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -31,6 +31,18 @@ jobs:
           name: ttbl-mac_x64
           path: dist/ttbl/ttbl-mac_x64.app
 
+      - name: Upload Windows
+        uses: actions/upload-artifact@v3
+        with:
+          name: ttbl-win_x64
+          path: dist/ttbl/ttbl-win_x64.exe
+
+      - name: Upload WebView2Loader.ddl
+        uses: actions/upload-artifact@v3
+        with:
+          name: WebView2Loader.ddl
+          path: dist/ttbl/WebView2Loader.dll
+
       - name: Upload ttbl-linux_arm64
         uses: actions/upload-artifact@v3
         with:
@@ -48,37 +60,3 @@ jobs:
         with:
           name: ttbl-linux_x64
           path: dist/ttbl/ttbl-linux_x64
-  deploy-windows:
-    name: Compile Windows Application
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 16.x
-
-      - name: Build App
-        run: |
-          npm i -g @neutralinojs/neu
-          git submodule update --init --recursive
-          neu update
-          neu build
-
-      - name: Upload Windows
-        uses: actions/upload-artifact@v3
-        with:
-          name: ttbl-win_x64
-          path: dist/ttbl/ttbl-win_x64.app
-
-      - name: Upload WebView2Loader.ddl
-        uses: actions/upload-artifact@v3
-        with:
-          name: WebView2Loader.ddl
-          path: dist/ttbl/WebView2Loader.ddl
-
-      - name: Upload Windows Folder
-        uses: actions/upload-artifact@v3
-        with:
-          name: ttbl-win
-          path: dist/ttbl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,3 +76,9 @@ jobs:
         with:
           name: WebView2Loader.ddl
           path: dist/ttbl/WebView2Loader.ddl
+
+      - name: Upload Windows Folder
+        uses: actions/upload-artifact@v3
+        with:
+          name: ttbl-win
+          path: dist/ttbl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   deploy:
     name: Compile Application
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,39 @@ jobs:
           cd dist/ttbl
           mv ttbl-mac_x64 ttbl-mac_x64.app
           chmod +x ttbl-mac_x64.app
-      - name: Upload Artifacts
+
+      - name: Upload MacOS
         uses: actions/upload-artifact@v3
         with:
-          name: build
-          path: dist/ttbl
+          name: ttbl-mac_x64
+          path: dist/ttbl/ttbl-mac_x64.app
+
+      - name: Upload Windows
+        uses: actions/upload-artifact@v3
+        with:
+          name: ttbl-win_x64
+          path: dist/ttbl/ttbl-win_x64.app
+
+      - name: Upload WebView2Loader.ddl
+        uses: actions/upload-artifact@v3
+        with:
+          name: WebView2Loader.ddl
+          path: dist/ttbl/WebView2Loader.ddl
+
+      - name: Upload ttbl-linux_arm64
+        uses: actions/upload-artifact@v3
+        with:
+          name: ttbl-linux_arm64
+          path: dist/ttbl/ttbl-linux_arm64
+
+      - name: Upload ttbl-linux_armhf
+        uses: actions/upload-artifact@v3
+        with:
+          name: ttbl-linux_armhf
+          path: dist/ttbl/ttbl-linux_armhf
+
+      - name: Upload ttbl-linux_x64
+        uses: actions/upload-artifact@v3
+        with:
+          name: ttbl-linux_x64
+          path: dist/ttbl/ttbl-linux_x64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,9 @@ on:
     branches: [ main ]
 
 jobs:
-  deploy:
-    name: Compile Application
-    runs-on: macos-latest
+  deploy-macos-linux:
+    name: Compile MacOS/Linux Application
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
@@ -31,18 +31,6 @@ jobs:
           name: ttbl-mac_x64
           path: dist/ttbl/ttbl-mac_x64.app
 
-      - name: Upload Windows
-        uses: actions/upload-artifact@v3
-        with:
-          name: ttbl-win_x64
-          path: dist/ttbl/ttbl-win_x64.app
-
-      - name: Upload WebView2Loader.ddl
-        uses: actions/upload-artifact@v3
-        with:
-          name: WebView2Loader.ddl
-          path: dist/ttbl/WebView2Loader.ddl
-
       - name: Upload ttbl-linux_arm64
         uses: actions/upload-artifact@v3
         with:
@@ -60,3 +48,31 @@ jobs:
         with:
           name: ttbl-linux_x64
           path: dist/ttbl/ttbl-linux_x64
+  deploy-windows:
+    name: Compile Windows Application
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+
+      - name: Build App
+        run: |
+          npm i -g @neutralinojs/neu
+          git submodule update --init --recursive
+          neu update
+          neu build
+
+      - name: Upload Windows
+        uses: actions/upload-artifact@v3
+        with:
+          name: ttbl-win_x64
+          path: dist/ttbl/ttbl-win_x64.app
+
+      - name: Upload WebView2Loader.ddl
+        uses: actions/upload-artifact@v3
+        with:
+          name: WebView2Loader.ddl
+          path: dist/ttbl/WebView2Loader.ddl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Create Executables
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    name: Compile Application
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+
+      - name: Build App
+        run: |
+          npm i -g @neutralinojs/neu
+          git submodule update --init --recursive
+          neu update
+          neu build
+          cd dist/ttbl
+          mv ttbl-mac_x64 ttbl-mac_x64.app
+          chmod +x ttbl-mac_x64.app
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build
+          path: dist/ttbl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,3 +60,9 @@ jobs:
         with:
           name: ttbl-linux_x64
           path: dist/ttbl/ttbl-linux_x64
+
+      - name: Upload resources.neu
+        uses: actions/upload-artifact@v3
+        with:
+          name: resources.neu
+          path: dist/ttbl/resources.neu

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ neutralino.js
 .storage
 *.log
 /.tmp
+
+# IntelliJ Based Files
+/.idea/

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Note: still in development
 ## Credit
 * This app was built with [Neutralinojs](https://github.com/neutralinojs/neutralinojs).
 * This app uses [dayjs](https://github.com/iamkun/dayjs) to implement asynchronous syncing.
-* [ttbl-cli](https://github.com/gaoDean/ttbl-cli) uses the CaulfieldLife endpoints from [here](https://github.com/garv-shah/caulfieldsync).
+* [ttbl-cli](https://github.com/gaoDean/ttbl-cli) uses [CaulfieldSync](https://caulfieldsync.vercel.app) to access the CaulfieldLife endpoints.


### PR DESCRIPTION
Added automatic distribution builds using GitHub Actions
Note: the MacOS build doesn't exactly seem to be working, producing the error documented in [this](https://github.com/neutralinojs/neutralinojs/issues/964) issue. This may possibly be an error relating to Neutralino